### PR TITLE
Deal with illegal m.room.avatar events

### DIFF
--- a/synapse-purge.py
+++ b/synapse-purge.py
@@ -115,7 +115,11 @@ def get_important_media_ids(db: postgres.Postgres) -> Set[str]:
             if avatar_url:
                 media_ids.add(avatar_url)
         elif data["type"] == "m.room.avatar":
-            media_ids.add(content["url"])
+            url = content.get("url")
+            if url:
+                media_ids.add(url)
+            else:
+                logger.error("No URL defined for m.room.avatar event: {!r}", event)
 
     return set(urllib.parse.urlsplit(url).path[1:] for url in media_ids)
 


### PR DESCRIPTION
Unsure how m.room.avatar events without a URL can get created, but they
exist:
```
{
  "auth_events": [
    "$censored",
    "$censored",
    "$censored"
  ],
  "prev_events": [
    "$censored"
  ],
  "type": "m.room.avatar",
  "room_id": "!censored",
  "sender": "@censored",
  "content": {},
  "depth": 32,
  "prev_state": [],
  "state_key": "",
  "origin": "XXX.YYY",
  "origin_server_ts": 1588281033781,
  "hashes": {
    "sha256": "censored"
  },
  "signatures": {
    "censored": {
      "ed25519:a_MVfW": "censored"
    }
  },
  "unsigned": {
    "age_ts": 1588281033781,
    "replaces_state": "$censored"
  }
}
```

This commit keeps synapse-purge from crashing when encountering such
messages.