### PR TITLE
Don't fail crontab when run as different user

### DIFF
--- a/docker-cmd-cron.sh
+++ b/docker-cmd-cron.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-cp .crontab.docker .crontab
-sed -i "s~SYNAPSE_PURGE_DOCKER_CRON_SCHEDULE~$SYNAPSE_PURGE_DOCKER_CRON_SCHEDULE~g" .crontab
+cp .crontab.docker /tmp/.crontab
+sed -i "s~SYNAPSE_PURGE_DOCKER_CRON_SCHEDULE~$SYNAPSE_PURGE_DOCKER_CRON_SCHEDULE~g" /tmp/.crontab
 
 source venv/bin/activate
 
@@ -12,6 +12,6 @@ stop() {
 
 trap "stop" SIGTERM
 
-supercronic .crontab &
+supercronic /tmp/.crontab &
 
 wait $!


### PR DESCRIPTION
When the container runs as a different user (`docker run --user=991:991`) then at creationtime, the copy fails due to permission error.
By writing the crontabfile to a writable place, this is circumvented.

Running the container as a different user is needed so it can access the synapse media_uploads directories which are (in my case) owned 991:991.